### PR TITLE
Skip alpha python modules

### DIFF
--- a/lib/OOCEapps/PkgUpd/PyMod.pm
+++ b/lib/OOCEapps/PkgUpd/PyMod.pm
@@ -21,9 +21,9 @@ sub getVersions {
     $name = $self->extractName($name);
     # enum is a backport from python3
     $name .= '34' if $name eq 'enum';
-    return [
+    return [ grep { ! /a\d+$/ }
         map { $_->text // () } $res->dom->find('p.release__version a')->each
-    ]
+    ];
 }
 
 1;


### PR DESCRIPTION
Some python modules have started using suffixes for alpha package versions  - this change ignores them.

Package | Version
--- | ---
library/python-3/coverage-35 | 4.5.1 -> 5.0a1 |  
library/python-3/jsonschema-35 | 2.6.0 -> 3.0.0a1

