### PR TITLE
Handle recent AMD ucode updates

### DIFF
--- a/lib/OOCEapps/PkgUpd/AMDuc.pm
+++ b/lib/OOCEapps/PkgUpd/AMDuc.pm
@@ -16,8 +16,8 @@ sub getVersions {
     my $res  = shift;
 
     return [
-        map { local $_ = $_; s/-//g; $_ }
-        $res->dom->find('div.content table tr td:first-child span')->map('text')->each
+        map { local $_ = $_; s/-//g; s/\s.*//; $_ }
+        $res->dom->find('div.content table tr td:first-child span')->map(attr => 'title')->each
     ];
 }
 


### PR DESCRIPTION
Recent updates don't have the date in the span column but have the number of elapsed hours instead:

```
<span class="age-hours" title="2022-08-10 07:55:45 -0400">30 hours</span>
```
versus
```
<span title="2022-04-11 07:13:23 -0400">2022-04-11</span>
```