### PR TITLE
irclog: join/part messages should be last to avoid messages not being…

### DIFF
--- a/lib/OOCEapps/Controller/Log.pm
+++ b/lib/OOCEapps/Controller/Log.pm
@@ -23,8 +23,11 @@ sub chanlog {
         [ qw(nick ts command message message_id) ],
         { 'channel' => $chan, 'ts' => { '-between' => [ $start, $end ] } },
         {
-            order_by => [ qw(ts message_id) ],
-            limit    => $c->model->config->{max_records}
+            order_by => [
+                \[ q{iif(command in ('JOIN', 'PART', 'QUIT'), 1, 0)} ],
+                [ qw(ts message_id) ],
+            ],
+            limit => $c->model->config->{max_records}
         }
     )->then(sub {
         $c->render(json => shift->hashes->to_array);


### PR DESCRIPTION
… displayed due to the message limit if there was a join/part flood