### PR TITLE
patrons: return will only exit eval block, not the whole sub leading …

### DIFF
--- a/lib/OOCEapps/Controller/Patron.pm
+++ b/lib/OOCEapps/Controller/Patron.pm
@@ -87,7 +87,7 @@ sub webhook {
                 format   => 'txt')
         } ($data->{type}, "$data->{type}.subject");
 
-        return $c->render(json => { status => 'error' }) if !($mail && $subj);
+        die [ "unsupported type for webhook: '$data->{type}'" ] if !($mail && $subj);
 
         OOCEapps::Utils::sendMail(
             { to => $data->{data}{customer}{email}, bcc => $c->config->{emailBcc} },


### PR DESCRIPTION
…to double rendering